### PR TITLE
fix typo in the name of webpack plugin

### DIFF
--- a/webpack/makeConfig.js
+++ b/webpack/makeConfig.js
@@ -114,7 +114,7 @@ export default function makeConfig(isDevelopment) {
       ];
       if (isDevelopment) {
         plugins.push(
-          new webpack.optimize.OccurenceOrderPlugin(),
+          new webpack.optimize.OccurrenceOrderPlugin(),
           new webpack.HotModuleReplacementPlugin(),
           new webpack.NoErrorsPlugin(),
           webpackIsomorphicToolsPlugin.development()
@@ -127,7 +127,7 @@ export default function makeConfig(isDevelopment) {
             allChunks: true
           }),
           new webpack.optimize.DedupePlugin(),
-          new webpack.optimize.OccurenceOrderPlugin(),
+          new webpack.optimize.OccurrenceOrderPlugin(),
           new webpack.optimize.UglifyJsPlugin({
             compress: {
               screw_ie8: true, // eslint-disable-line camelcase


### PR DESCRIPTION
There is typo in the name of webpack plugin. https://webpack.github.io/docs/list-of-plugins.html#occurrenceorderplugin